### PR TITLE
fix backward and forward using imwheel

### DIFF
--- a/.setup/options/web-develop/setup.sh
+++ b/.setup/options/web-develop/setup.sh
@@ -100,8 +100,8 @@ if ! command -v $COMMAND_NAME &>/dev/null; then
     curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
     source ~/.profile
     reset
-    nvm install node
-    nvm install 18.7.0
+    # nvm install node
+    # nvm install 18.7.0
 else
     echo "$COMMAND_NAME install ok installed"
 fi

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -45,6 +45,7 @@ Shift_L,   Up,   Shift_L|Button4
 Shift_L,   Down, Shift_L|Button5
 EOF
     imwheel --kill
+    sudo imwheel --kill --buttons "4 5"
 fi
 
 echo "=========================== set time on dual boot system ==========================="


### PR DESCRIPTION
https://askubuntu.com/questions/421645/imwheel-destroys-back-forth-navigation-buttons-from-my-mouse

every time --kill or --buttons or -c is launched, there is a competing instance already running.

Try single line --kill and --buttons:

sudo imwheel --kill --buttons "4 5"
or
sudo imwheel -k -b "4 5"